### PR TITLE
fix: update MITRE technique from T1562 to T1484 for allowlisted domains rule

### DIFF
--- a/rules/domain_added_to_google_workspace_allowlisted_domains.yml
+++ b/rules/domain_added_to_google_workspace_allowlisted_domains.yml
@@ -24,6 +24,6 @@ run_frequency_s: 60
 event_sink_keys:
 - medium_severity_alerts
 tags:
-- techniques.t1562.impair_defenses
+- techniques.t1484.domain_or_tenant_policy_modification
 - source.gsuite
 - tactics.ta0005.defense_evasion


### PR DESCRIPTION
## Summary

This PR updates the MITRE ATT&CK technique mapping for the "Domain added to Google Workspace allowlisted domains" detection rule.

## Change

- **From:** `T1562 - Impair Defenses`
- **To:** `T1484 - Domain or Tenant Policy Modification`

## Rationale

Adding a domain to Google Workspace's allowlisted domains modifies the organization's trust policies at the tenant level. This action is more accurately categorized under [T1484 (Domain or Tenant Policy Modification)](https://attack.mitre.org/techniques/T1484/) rather than [T1562 (Impair Defenses)](https://attack.mitre.org/techniques/T1562/).

T1484 specifically covers adversary actions that modify domain or tenant-level policies to facilitate their objectives — which directly aligns with adding a trusted domain to lower security controls for data exfiltration or collection (as described in the rule's strategy). T1562, on the other hand, focuses on directly disabling or tampering with defensive tools and mechanisms (e.g., disabling logging, modifying firewall rules).

The tactic remains **TA0005 (Defense Evasion)**, as T1484 also falls under this tactic.

---

Co-Authored-By: Oz <oz-agent@warp.dev>

[Warp conversation](https://app.warp.dev/conversation/ee5fa9db-3f8a-4cc7-8cdf-8dd2a224156d)